### PR TITLE
feat: Add ability to extract RSA public key parameters

### DIFF
--- a/lib/uasn1.py
+++ b/lib/uasn1.py
@@ -411,8 +411,14 @@ class Decoder(object):
 
     def _decode_bit_string(self, bytes_data):
         """Decode a bit string"""
-        a = binascii.b2a_base64(bytes_data)
-        return a.decode().rstrip('\n')
+        if bytes_data[0] == 0x00:
+            # trivial case of no zero padding :)
+            # slice out the leading null byte
+            a = binascii.b2a_base64(bytes_data[1:len(bytes_data)])
+            return a.decode().rstrip('\n')
+        else:
+            # TODO implement what's needed to deal with zero padding
+            raise Error('ASN1 Bit String with zero padding')
 
     def _decode_null(self, bytes_data):
         """Decode a Null value."""

--- a/lib/uasn1.py
+++ b/lib/uasn1.py
@@ -8,6 +8,7 @@
 
 Boolean = 0x01
 Integer = 0x02
+BitString = 0x03
 OctetString = 0x04
 Null = 0x05
 ObjectIdentifier = 0x06
@@ -333,6 +334,8 @@ class Decoder(object):
         bytes_data = self._read_bytes(length)
         if nr == Boolean:
             value = self._decode_boolean(bytes_data)
+        elif nr == BitString:
+            value = self._decode_bit_string(bytes_data)
         elif nr in (Integer, Enumerated):
             value = self._decode_integer(bytes_data)
         elif nr == OctetString:
@@ -403,6 +406,11 @@ class Decoder(object):
 
     def _decode_octet_string(self, bytes_data):
         """Decode an octet string."""
+        a = binascii.b2a_base64(bytes_data)
+        return a.decode().rstrip('\n')
+
+    def _decode_bit_string(self, bytes_data):
+        """Decode a bit string"""
         a = binascii.b2a_base64(bytes_data)
         return a.decode().rstrip('\n')
 

--- a/pem_service.py
+++ b/pem_service.py
@@ -31,6 +31,8 @@ def strid(id):
         s = 'BOOLEAN'
     elif id == uasn1.Integer:
         s = 'INTEGER'
+    elif id == uasn1.BitString:
+        s = 'BIT STRING'
     elif id == uasn1.OctetString:
         s = 'OCTET STRING'
     elif id == uasn1.Null:
@@ -43,12 +45,10 @@ def strid(id):
         s = 'SEQUENCE'
     elif id == uasn1.Set:
         s = 'SET'
-    elif id == uasn1.Null:
-        s = 'NULL'
     else:
         s = '%#02x' % id
     return s
- 
+
 def strclass(id):
     """Return a string representation of an ASN.1 class."""
     if id == uasn1.ClassUniversal:
@@ -57,7 +57,7 @@ def strclass(id):
         s = 'APPLICATION'
     elif id == uasn1.ClassContext:
         s = 'CONTEXT'
-    elif id == san1.ClassPrivate:
+    elif id == uasn1.ClassPrivate:
         s = 'PRIVATE'
     else:
         raise ValueError('Illegal class: %#02x' % id)
@@ -115,6 +115,43 @@ def get_pem_parameters(pem):
         # text.append(str(i))
     return result #, text
 
+def get_pub_parameters(pkcs1):
+    formatted_pkcs1 = format_pub(pkcs1)
+    input_data = read_pem(formatted_pkcs1)
+    data = []
+    for line in input_data:
+        data.append(line)
+    if isinstance(data[0], str):
+        data = b''.join(data)
+    elif isinstance(data[0], int):
+        data = bytes(data)
+    else:
+        print('invalid data')
+
+    dec = uasn1.Decoder()
+    dec.start(data)
+
+    s = io.StringIO()
+    prettyprint(dec, s)
+    #print(s.getvalue())
+    value = s.getvalue().split('\n')[4] # bit string encoding integers
+    value = value.replace('  [UNIVERSAL] BIT STRING (value ', '')
+    value = value.replace(')', '')
+    # remove spurious null byte at start of sequence from bit string
+    trunc = ubinascii.a2b_base64(value)[1:271]
+    dec.start(trunc)
+    ss = io.StringIO()
+    prettyprint(dec, ss)
+    #print(ss.getvalue())
+    values = ss.getvalue().split('\n')[1:3] # rsa integer and exponent
+    #print(values)
+    result = []
+    for i in values:
+        i = i.replace('  [UNIVERSAL] INTEGER (value ', '')
+        i = i.replace(')', '')
+        result.append(int(i))
+    return result
+
 def get_pem_key(pkcs8):
     formatted_pkcs8 = format_pem(pkcs8)
     input_data = read_pem(formatted_pkcs8)
@@ -134,7 +171,7 @@ def get_pem_key(pkcs8):
     s = io.StringIO()
     prettyprint(dec, s)
     # print(s.getvalue())
-    value = s.getvalue().split('\n')[5] # get the indexes [2 -> 6]
+    value = s.getvalue().split('\n')[5] # octet string encoding integers
     value = value.replace('  [UNIVERSAL] OCTET STRING (value ', '')
     value = value.replace(')', '')
     # print(value)
@@ -148,3 +185,12 @@ def format_pem(pem):
     pem_list.append("-----END RSA PRIVATE KEY-----")
     
     return pem_list
+
+def format_pub(pub):
+    pub_list = []
+    for i in range(0, len(pub), 64):
+        pub_list.append(pub[i:i+64])
+    pub_list.insert(0, "-----BEGIN RSA PUBLIC KEY-----")
+    pub_list.append("-----END RSA PUBLIC KEY-----")
+    
+    return pub_list

--- a/pem_service.py
+++ b/pem_service.py
@@ -137,9 +137,7 @@ def get_pub_parameters(pkcs1):
     value = s.getvalue().split('\n')[4] # bit string encoding integers
     value = value.replace('  [UNIVERSAL] BIT STRING (value ', '')
     value = value.replace(')', '')
-    # remove spurious null byte at start of sequence from bit string
-    trunc = ubinascii.a2b_base64(value)[1:271]
-    dec.start(trunc)
+    dec.start(ubinascii.a2b_base64(value))
     ss = io.StringIO()
     prettyprint(dec, ss)
     #print(ss.getvalue())


### PR DESCRIPTION
Ongoing work for https://github.com/atsign-foundation/micropython/issues/2 requires the ability to extract integers from another atSign's public key.

**- What I did**

Tidied up the work done by @duanqi211 to add Bit String support to `uasn1.py`

Added a method to extract public key integers.

**- How I did it**

Getting the parameters from a public key is very similar to doing the same with a private key, except that they're encoded into a Bit String rather than an Octet String.

One trip hazard encountered is the spurious null byte at the beginning of the sequence extracted from the bit string, which throws off the ASN.1 parser if it's not trimmed out. @realvarx @TylerTrott @JeremyTubongbanua @XavierChanth any thoughts on how/why this is happening would be appreciated?

**- How to verify it**

Running `micropython` locally on WSL2:

```
import sys
sys.path.append('./lib')
from pem_service import get_pem_parameters, get_pub_parameters, get_pem_key
pubpem='MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArm6AMIrw+2lAPvXVNulIcjabLbhDIynXIMIwjoLGOHKgjvuALW9gySiIDBUG54wtsD15etVL9NSGVchjAoZi7H3NAKQCyn1UNaKzL7Bxnqdm+GyX1OtAQTTFEcqzQZmQDrhTNRs2W2GNaQ+NXEIETfeBxD/VNsumIrzUCybJfRGHcYj5XCcku7YvdluiO+VhQHH1mdGuKuunONo2czNa/0Ir27rWo1SB43jMfbzR/duUT3xD3tB2y+NdWSozbe4dnrCTip4yJ2gdqXwThfK8l2wr/QB/NcLhWcAEo9kQDboOKsS91f3ba7zcBao7Z0lfY/yF2i+dCXB0QA2mmzE6QQIDAQAB'
print(get_pub_parameters(pubpem))
```

Example output:

```
[22019955010203162012544509859681164488930880432261972458899838175754293611805217089916406940112100721734274388147856483780254109148070008367596231568313961662789496989123745899284270182818488572671086203864082243948488737628459929294695956520594608527748960101978987192974848362310384109216948438946485471834986032338428092083698086017140393675485856360534183839432285060596258898230833036180671422861642200309962484563154992547400750879332457266064473574420436143142612640028499344486953806118226974258478244812723412044668846945795043769351304074262759431478803683125647954039718875283087402759554272630345833724481, 65537]
```

**- Description for the changelog**

feat: Add ability to extract RSA public key parameters