### PR TITLE
fix: Get rsa.decrypt working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 project.pico-go
+__pycache__

--- a/lib/third_party/rsa/pkcs1.py
+++ b/lib/third_party/rsa/pkcs1.py
@@ -246,7 +246,7 @@ def decrypt(crypto, priv_key):
         sep_idx = cleartext.index(b'\x00', 2)
     except ValueError:
         raise DecryptionError('Decryption failed')
-    print(cleartext)
+
     return cleartext[sep_idx + 1:]
 
 

--- a/lib/third_party/rsa/pkcs1.py
+++ b/lib/third_party/rsa/pkcs1.py
@@ -238,7 +238,7 @@ def decrypt(crypto, priv_key):
     ## Seems what we actually get is b' \x02'
     ## A space instead of a null
     # If we can't find the cleartext marker, decryption failed.
-    if ((cleartext[0:2] != b'\x00\x02') & (cleartext[0:2] != b' \x02')):
+    if not ((cleartext[0:2] == b'\x00\x02') | (cleartext[0:2] == b' \x02')):
         raise DecryptionError('Decryption failed')
 
     # Find the 00 separator between the padding and the message

--- a/lib/third_party/rsa/pkcs1.py
+++ b/lib/third_party/rsa/pkcs1.py
@@ -234,8 +234,11 @@ def decrypt(crypto, priv_key):
     decrypted = priv_key.blinded_decrypt(encrypted)
     cleartext = transform.int2bytes(decrypted, blocksize)
 
+    ## The test for b'\x00\x02' was always failing :(
+    ## Seems what we actually get is b' \x02'
+    ## A space instead of a null
     # If we can't find the cleartext marker, decryption failed.
-    if cleartext[0:2] != b'\x00\x02':
+    if ((cleartext[0:2] != b'\x00\x02') & (cleartext[0:2] != b' \x02')):
         raise DecryptionError('Decryption failed')
 
     # Find the 00 separator between the padding and the message
@@ -243,7 +246,7 @@ def decrypt(crypto, priv_key):
         sep_idx = cleartext.index(b'\x00', 2)
     except ValueError:
         raise DecryptionError('Decryption failed')
-
+    print(cleartext)
     return cleartext[sep_idx + 1:]
 
 


### PR DESCRIPTION
`rsa.decrypt` was always failing as this test always returned true:

```
if cleartext[0:2] != b'\x00\x02':
```

It seems that the leading characters for the cleartext we're getting are b' \x02' - a space instead of a null

This isn't happening at the padding stage before encryption, which is correct. But I've not been able to track down where that b'\x20' is creeping in.

**- What I did**

Allow the test to pass when it finds b' \x02' (as well as b'\x00\x02')

Also added __pycache__ to .gitignore

**- How I did it**

Looked at raw cleartext to see why the test was failing and observed a leading space rather than the null that should be there.

**- How to verify it**

```micropython
import sys
import ubinascii
sys.path.append('./lib')
from pem_service import get_pem_parameters, get_pub_parameters, get_pem_key
from third_party import rsa
encryptpub='A_PEM_encoded_RSA_public_key'
encryptpriv='A_PEM_encoded_RSA_private_key'
pubKey = get_pub_parameters(encryptpub)
print(pubKey)
rsapub = rsa.PublicKey(pubKey[0], pubKey[1])
privKey = get_pem_parameters(get_pem_key(encryptpriv))
print(privKey)
rsapriv = rsa.PrivateKey(privKey[0], privKey[1], privKey[2], privKey[3], privKey[4])
enchello = rsa.encrypt(b'hello world', rsapub)
print(rsa.decrypt(enchello, rsapriv))
```

**- Description for the changelog**

fix: Get rsa.decrypt working